### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/server/worker-configuration.d.ts
+++ b/server/worker-configuration.d.ts
@@ -5691,7 +5691,7 @@ interface Hyperdrive {
   /**
    * Connect directly to Hyperdrive as if it's your database, returning a TCP socket.
    *
-   * Calling this method returns an idential socket to if you call
+   * Calling this method returns an identical socket to if you call
    * `connect("host:port")` using the `host` and `port` fields from this object.
    * Pick whichever approach works better with your preferred DB client library.
    *
@@ -5938,7 +5938,7 @@ declare module 'cloudflare:pipelines' {
     protected ctx: ExecutionContext
     constructor(ctx: ExecutionContext, env: Env)
     /**
-     * run recieves an array of PipelineRecord which can be
+     * run receives an array of PipelineRecord which can be
      * transformed and returned to the pipeline
      * @param records Incoming records from the pipeline to be transformed
      * @param metadata Information about the specific pipeline calling the transformation entrypoint


### PR DESCRIPTION


Description:  
This pull request corrects two typographical errors in the documentation comments within the `server/worker-configuration.d.ts` file:
- Changed "idential" to "identical"
- Changed "recieves" to "receives"

These changes improve the clarity and professionalism of the code documentation. No functional code was modified.
